### PR TITLE
Guard file uploads and harden analysis CSV/GeoJSON parsing

### DIFF
--- a/dev/AGENTS.md
+++ b/dev/AGENTS.md
@@ -25,3 +25,4 @@ This file acts as a shared memory and change log for the **Random Geo Points** p
 - 2025-12-12: Hardened AOI/strata loading (FeatureCollection normalization) and seed handling to prevent undefined length errors; removed non-ASCII UI glyphs.
 - 2025-12-14: Created `FULL_DEVELOPMENT_PLAN.md` detailing the v2 roadmap, architecture, and feature prioritization. Defined scope for Stratified Sampling logic, Olofsson Analysis Engine, and Protocol Builder.
 - 2025-12-15: Fixed AOI point-in-polygon checks to support FeatureCollections and keep cluster samples inside the AOI.
+- 2026-01-12: Guarded file input handling and analysis parsing to avoid empty uploads causing errors.

--- a/index.html
+++ b/index.html
@@ -1125,12 +1125,18 @@
       const el = document.getElementById(id);
       const inp = document.getElementById(inputId);
       el.onclick = () => inp.click();
-      inp.onchange = async (e) => cb(e.target.files[0], el);
+      inp.onchange = async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        cb(file, el);
+      };
       el.ondragover = (e) => { e.preventDefault(); el.classList.add('active'); };
       el.ondragleave = () => el.classList.remove('active');
       el.ondrop = async (e) => {
         e.preventDefault(); el.classList.remove('active');
-        cb(e.dataTransfer.files[0], el);
+        const file = e.dataTransfer.files[0];
+        if (!file) return;
+        cb(file, el);
       };
     };
 
@@ -1443,6 +1449,10 @@
       } else {
         // Simple CSV parser
         const lines = txt.split('\n').map(l => l.trim()).filter(l => l);
+        if (lines.length < 2) {
+          alert('Result file needs a header row and at least one data row.');
+          return;
+        }
         const headers = lines[0].split(',');
         data = lines.slice(1).map(l => {
           const vals = l.split(',');
@@ -1452,11 +1462,20 @@
         });
       }
 
+      if (!data.length) {
+        alert('Result file did not contain any records.');
+        return;
+      }
+
       state.analysisData = data;
       el.innerHTML = `<div>Loaded ${data.length} records</div>`;
 
       // Populate Column Selects
-      const cols = Object.keys(data[0]);
+      const cols = Object.keys(data[0] || {});
+      if (!cols.length) {
+        alert('Result file needs column headers.');
+        return;
+      }
       const populate = (id) => {
         const s = document.getElementById(id); s.innerHTML = '';
         cols.forEach(c => {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when a user cancels a file dialog or drops nothing into a drop zone by guarding against empty file objects.
- Make the analysis import flow more robust against malformed or empty CSV/GeoJSON uploads that previously caused uncaught errors.
- Improve UX by surfacing clear alerts when uploaded results lack headers or data rows.

### Description
- Add guards in `setupDrop` so `inp.onchange` and `el.ondrop` ignore empty selections/drops and only call the callback with a valid `file`.
- Harden result parsing in the `resDrop` handler by validating CSV content (`lines.length < 2`), checking parsed `data.length`, and validating presence of columns with `Object.keys(data[0] || {})` before populating selectors.
- Preserve existing behavior for valid AOI/strata uploads and sampling logic while preventing no-op or error states on empty inputs.
- Record the change in `dev/AGENTS.md` change log.

### Testing
- Ran `npx htmlhint index.html` which installed `htmlhint` and reported: "Scanned 1 files, no errors found.".
- Confirmed no lint errors after changes (automated check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965880d99a08327b399d11ad7c55e7c)